### PR TITLE
Fix a use-after-free error in tickit_window_destroy()

### DIFF
--- a/src/window.c
+++ b/src/window.c
@@ -379,8 +379,8 @@ void tickit_window_destroy(TickitWindow *win)
   for(TickitWindow *child = win->first_child; child; /**/) {
     TickitWindow *next = child->next;
 
-    tickit_window_unref(child);
     child->parent = NULL;
+    tickit_window_unref(child);
     child = next;
   }
 


### PR DESCRIPTION
Hi Paul, I tracked a long-standing memory corruption issue with the Tickit-* Perl modules in 
https://bugs.debian.org/1078154 down to this use after free.

The related crashes are not very deterministic, but valgrind flags the issue quite consistently, as seen with this test program:

```
#include <tickit.h>
int main(void) {
        Tickit *t = tickit_new_stdtty();
        TickitRect rect = { .top = 0, .left = 0, .lines = 1, .cols = 1 };
        TickitWindow *w = tickit_get_rootwin(t);
        TickitWindow *w2 = tickit_window_new(w, rect, 0);
        tickit_window_expose(w, &rect);
        tickit_unref(t);
}
```

which gives

```
  ==3516376== Invalid write of size 8
  ==3516376==    at 0x48741CF: tickit_window_destroy (in /usr/lib/x86_64-linux-gnu/libtickit.so.3.0.0)
  ==3516376==    by 0x4872395: tickit_unref (in /usr/lib/x86_64-linux-gnu/libtickit.so.3.0.0)
  ==3516376==    by 0x1091F1: main (in /home/ntyni/1078154/a.out)
  ==3516376==  Address 0x4aba9c0 is 0 bytes inside a block of size 96 free'd
  ==3516376==    at 0x48451EF: free (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
  ==3516376==    by 0x48741CE: tickit_window_destroy (in /usr/lib/x86_64-linux-gnu/libtickit.so.3.0.0)
  ==3516376==    by 0x4872395: tickit_unref (in /usr/lib/x86_64-linux-gnu/libtickit.so.3.0.0)
  ==3516376==    by 0x1091F1: main (in /home/ntyni/1078154/a.out)
  ==3516376==  Block was alloc'd at
  ==3516376==    at 0x4842808: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
  ==3516376==    by 0x4874069: tickit_window_new (in /usr/lib/x86_64-linux-gnu/libtickit.so.3.0.0)
  ==3516376==    by 0x1091CE: main (in /home/ntyni/1078154/a.out)
```

